### PR TITLE
Add the syncServerUrl to bugsnag context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ android/gradle.properties
 
 # Bundle artifact
 *.jsbundle
+android/app/debug/
+android-release.bundle*

--- a/src/features/Bluetooth/Download/DownloadSlice.ts
+++ b/src/features/Bluetooth/Download/DownloadSlice.ts
@@ -194,8 +194,10 @@ function* downloadTemperatures(): SagaIterator {
     const mapper = ({ id }: SensorState) => put(DownloadAction.tryPassiveDownloadForSensor(id));
     const actions = sensors.map(mapper);
     yield all(actions);
-    // eslint-disable-next-line no-empty
-  } catch (error) {}
+  } catch (error) {
+    // This shouldn't happen as we are catching errors in tryDownloadForSensor
+    console.error(`Error in downloadTemperatures: ${(error as Error)?.message}`);
+  }
 }
 
 function* startPassiveDownloading(): SagaIterator {

--- a/src/features/Monitor/MonitorSlice.ts
+++ b/src/features/Monitor/MonitorSlice.ts
@@ -1,3 +1,4 @@
+import Bugsnag from '@bugsnag/react-native';
 import { SagaIterator } from '@redux-saga/types';
 import { createSlice } from '@reduxjs/toolkit';
 import { BleService } from 'msupply-ble-service';
@@ -49,6 +50,7 @@ function* startDependencyMonitor(): SagaIterator {
     if (now - start >= RESTART_INTERVAL_IN_SECONDS) {
       const loggerService = yield call(DependencyLocator.get, DEPENDENCY.LOGGER_SERVICE);
       loggerService.info('Restarting bluetooth service');
+      Bugsnag.leaveBreadcrumb('Restarting bluetooth service');
       start = now;
       DependencyLocator.register('bleService', undefined);
       DependencyLocator.register('bleService', new BleService(new BleManager(), loggerService));


### PR DESCRIPTION
Adds the syncURL to bugsnag context, and a breadcrumb for BLE Server Restarts.
None of these are particularly important, but would be useful to at least have a URL to traceback when an error is logged.
Mainly wanted to do something to ensure it's working.

We could log a lot more errors (Bluetooth connection issues for example) maybe in future we have a debug setting to enable sending all these errors to bugsnag? We probably don't want every URL sync issue and every bluetooth connectivity issue sent, but would be helpful to be able to turn that on somehow. See also: #21 Better Bugsnag Breadcrumbing 

Also: adds a .gitignore for build files we don't want to commit