### PR TITLE
Don't restart bluetooth while downloading

### DIFF
--- a/src/features/Bluetooth/Download/DownloadSlice.ts
+++ b/src/features/Bluetooth/Download/DownloadSlice.ts
@@ -48,7 +48,7 @@ export const isSensorDownloading =
     }
   };
 
-const getIsDownloading = (state: RootState): boolean => {
+export const getIsDownloading = (state: RootState): boolean => {
   try {
     return Object.values(state.bluetooth.download.downloadingById).some(
       isDownloading => isDownloading


### PR DESCRIPTION
Don't restart bluetooth if there's a download in progress.
Might help with the missing data issues we've seen?
