### PR TITLE
273 consistent id for sensors when added

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "redux-flipper": "^2.0.1",
     "redux-logger": "^3.0.6",
     "redux-saga": "^1.1.3",
+    "ts-md5": "^1.3.1",
     "twix": "^1.3.0",
     "typeorm": "^0.2.32",
     "typescript": "^4.1.4",

--- a/src/common/services/UtilService/UtilService.ts
+++ b/src/common/services/UtilService/UtilService.ts
@@ -4,11 +4,17 @@ import generateUUID from 'react-native-uuid';
 import packageJson from '~/../../package.json';
 import { UnixTimestamp } from '~common/types/common';
 import { Seconds } from '~constants/Milliseconds';
+import { Md5 } from 'ts-md5';
 
 type NumberRange = [number, number];
 
 export class UtilService {
   uuid = (): string => generateUUID.v4() as string;
+  hashuid = (s: string): string => {
+    // use a hash algorithm to generate a unique id for the input string (mac address in our case)
+    const h = Md5.hashStr(s);
+    return h;
+  };
 
   now = (): UnixTimestamp => moment().unix();
 

--- a/src/features/Entities/Sensor/SensorManager.ts
+++ b/src/features/Entities/Sensor/SensorManager.ts
@@ -135,11 +135,15 @@ export class SensorManager {
     try {
       id = (await this.getSensorByMac(macAddress)).id;
     } catch (e) {
-      id = this.utils.uuid();
+      try {
+        id = this.utils.hashuid(macAddress);
+      } catch (e) {
+        console.error('===>Error creating hash', e);
+      }
     }
     // Just to make sure
     if (!id) {
-      id = this.utils.uuid();
+      id = this.utils.hashuid(macAddress);
     }
 
     const name = this.btUtils.deviceDescriptorToDevice(macAddress).id;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15434,6 +15434,11 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
+ts-md5@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ts-md5/-/ts-md5-1.3.1.tgz#f5b860c0d5241dd9bb4e909dd73991166403f511"
+  integrity sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg==
+
 ts-pnp@^1.1.2, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"


### PR DESCRIPTION
Closes #273 

Hashes the Mac Address to get a unique ID for the sensor.

I'm now wondering if we should just use the mac address directly instead though?
Not sure what we gain by hashing?