### PR TITLE
Remove regular notifications

### DIFF
--- a/src/features/Bluetooth/Scan/ScanSlice.ts
+++ b/src/features/Bluetooth/Scan/ScanSlice.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { eventChannel } from 'redux-saga';
 import { SagaIterator } from '@redux-saga/types';
 import { ActionReducerMapBuilder, createSlice } from '@reduxjs/toolkit';
-import { BleService, ScanCallback, BleError } from 'msupply-ble-service';
+import { BleService, BleError } from 'msupply-ble-service';
 import {
   take,
   getContext,

--- a/src/features/Monitor/MonitorSlice.ts
+++ b/src/features/Monitor/MonitorSlice.ts
@@ -62,7 +62,7 @@ function* startDependencyMonitor(): SagaIterator {
             Bugsnag.leaveBreadcrumb('Skipping bluetooth restart because we are downloading');
           }
         } catch (e) {
-          Bugsnag.notify(e);
+          Bugsnag.notify(e as Error);
           console.log(e);
         }
       }

--- a/src/ui/hooks/useForegroundService.ts
+++ b/src/ui/hooks/useForegroundService.ts
@@ -4,7 +4,6 @@ import { AppRegistry, NativeModules } from 'react-native';
 import { useOnMount } from '~hooks';
 import { DownloadAction, SettingSelector, SyncAction } from '~features';
 import Bugsnag from '@bugsnag/react-native';
-import { MILLISECONDS } from '~constants';
 
 export const useForegroundService = (): void => {
   const { Scheduler } = NativeModules;
@@ -17,12 +16,11 @@ export const useForegroundService = (): void => {
 
     // Send the sync url to bugsnag so we have more context for where an error is occurring
     Bugsnag.addMetadata('sync', 'serverUrl', serverUrl);
+    Scheduler.updateStatus('Running...');
 
     const schedulerTask = async () => {
-      Scheduler.updateStatus('Downloading logs');
       dispatch(DownloadAction.downloadTemperaturesStart());
       dispatch(SyncAction.tryIntegrating());
-      setTimeout(() => Scheduler.updateStatus('Idle'), MILLISECONDS.TEN_SECONDS);
     };
 
     try {

--- a/src/ui/hooks/usePowerState.ts
+++ b/src/ui/hooks/usePowerState.ts
@@ -46,7 +46,7 @@ const Action = {
   }),
   batteryLevelUpdated: (batteryLevel: number): PowerStateAction => ({
     type: PowerStateActionTypes.BatteryLevelUpdate,
-    payload: { batteryLevel: Math.ceil(batteryLevel * 100) },
+    payload: { batteryLevel: Math.round(batteryLevel * 100) },
   }),
   lowPowerModeUpdated: (isLowPowerMode: boolean): PowerStateAction => ({
     type: PowerStateActionTypes.LowPowerModeUpdate,
@@ -113,7 +113,7 @@ type BatteryLevelListener = (batteryLevel: BatteryLevel) => void;
 class BatteryLevelSubject {
   listeners: Record<number, BatteryLevelListener>;
 
-  intervalHandler: NodeJS.Timeout;
+  intervalHandler: ReturnType<typeof setInterval>;
 
   currentId: number;
 
@@ -137,11 +137,15 @@ class BatteryLevelSubject {
 
   start() {
     this.intervalHandler = setInterval(() => {
-      ExpoBattery.getBatteryLevelAsync().then(batteryLevel => {
-        Object.values(this.listeners).forEach(listener => {
-          listener(batteryLevel);
+      ExpoBattery.getBatteryLevelAsync()
+        .then(batteryLevel => {
+          Object.values(this.listeners).forEach(listener => {
+            listener(batteryLevel);
+          });
+        })
+        .catch(e => {
+          console.error('Error! get battery level failed:', e);
         });
-      });
     }, MILLISECONDS.TEN_SECONDS);
   }
 


### PR DESCRIPTION
Fixes #278 

Removed the notification update. Each time the notification updates the tablet would make a notification sound and vibration if configured. This is annoying and not worth the benefit of showing 'downloading' status, which wasn't entirely accurate anyway.