### PR TITLE
Re-order temperature_log and temperature_breach integration sync

### DIFF
--- a/src/features/Sync/SyncSlice.ts
+++ b/src/features/Sync/SyncSlice.ts
@@ -282,13 +282,13 @@ function* syncAll({
     try {
       yield put(SyncAction.syncSensors(`${serverUrl}/${ENDPOINT.SENSOR}`));
       yield take([SyncAction.syncSensorsSuccess, SyncAction.syncSensorsFailure]);
-      yield put(SyncAction.syncTemperatureLogs(`${serverUrl}/${ENDPOINT.TEMPERATURE_LOG}`));
-      yield take([SyncAction.syncTemperatureLogsSuccess, SyncAction.syncTemperatureLogsFailure]);
       yield put(SyncAction.syncTemperatureBreaches(`${serverUrl}/${ENDPOINT.TEMPERATURE_BREACH}`));
       yield take([
         SyncAction.syncTemperatureBreachesSuccess,
         SyncAction.syncTemperatureBreachesFailure,
       ]);
+      yield put(SyncAction.syncTemperatureLogs(`${serverUrl}/${ENDPOINT.TEMPERATURE_LOG}`));
+      yield take([SyncAction.syncTemperatureLogsSuccess, SyncAction.syncTemperatureLogsFailure]);
       yield put(SettingAction.update('lastSync', utils.now()));
     } catch (e) {
       console.error('syncAll error', e);


### PR DESCRIPTION
Fixes #290 

Sends the temperature breach records first, then temperature logs, which means the temperature logs changes won't fail with a foreign key constraint.

Note: Accidentally committed this to the develop branch 🫣

See: https://github.com/msupply-foundation/open-msupply/pull/2901 for more context if required