### PR TITLE
Stop deleting logs after downloading them...

### DIFF
--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -16,7 +16,7 @@ export { ICON } from './Icon';
 export { FORMAT } from './Format';
 export { CHART } from './Chart';
 export { NAVIGATION } from './Navigation';
-export { BLUETOOTH, BLUE_MAESTRO } from '@openmsupply/msupply-ble-service';
+export { BLUE_MAESTRO } from '@openmsupply/msupply-ble-service';
 export { SETTING } from './Setting';
 export { SPECIAL_CHARACTER } from './SpecialCharacter';
 export { ENVIRONMENT } from './Environment';

--- a/src/features/Bluetooth/Download/DownloadManager.ts
+++ b/src/features/Bluetooth/Download/DownloadManager.ts
@@ -60,7 +60,7 @@ export class DownloadManager {
 
     // Since we don't delete logs, we need to skip over logs that have already been saved.
     if (maxNumberToSave < logsToSave.length) {
-      this.logger?.info(`${sensor.id} maxNumberToSave is greater than logsToSave`);
+      this.logger?.info(`${sensor.id} maxNumberToSave is less than logsToSave`);
       const logsToSkip = logsToSave.length - maxNumberToSave;
       logsToSave.splice(0, logsToSkip);
     }

--- a/src/features/Bluetooth/Download/DownloadManager.ts
+++ b/src/features/Bluetooth/Download/DownloadManager.ts
@@ -54,6 +54,17 @@ export class DownloadManager {
     this.logger?.debug(
       `${sensor.id} Create logs. logsToSave: ${logsToSave.length}, sliceIndex: ${sliceIndex}, mostRecentLogTime: ${mostRecentLogTime}, now: ${now}`
     );
+
+    // The logs from the bluemaestro sensor don't have timestamps, we only have the time we downloaded them (aka now) and the log interval.
+    // We need to calculate the timestamp for each log, based on the log interval and the time we downloaded them.
+
+    // Since we don't delete logs, we need to skip over logs that have already been saved.
+    if (maxNumberToSave < logsToSave.length) {
+      this.logger?.info(`${sensor.id} maxNumberToSave is greater than logsToSave`);
+      const logsToSkip = logsToSave.length - maxNumberToSave;
+      logsToSave.splice(0, logsToSkip);
+    }
+
     let initial = 0;
     if (!mostRecentLogTime) {
       const lookbackSeconds = (logsToSave.length - 1) * logInterval;

--- a/src/features/Bluetooth/Download/DownloadSlice.ts
+++ b/src/features/Bluetooth/Download/DownloadSlice.ts
@@ -163,16 +163,6 @@ function* tryDownloadForSensor({
       );
 
       yield call(downloadManager.saveLogs, sensorLogs);
-      if (sensorLogs.length) {
-        yield call(
-          btService.updateLogIntervalWithRetries,
-          macAddress,
-          logInterval,
-          10,
-          false,
-          null
-        );
-      }
       yield put(ConsecutiveBreachAction.create(sensor));
       yield put(DownloadAction.passiveDownloadForSensorSuccess(sensor.id));
       yield put(CumulativeBreachAction.fetchListForSensor(sensorId));

--- a/src/features/Entities/TemperatureLog/TemperatureLogManager.ts
+++ b/src/features/Entities/TemperatureLog/TemperatureLogManager.ts
@@ -14,10 +14,10 @@ export class TemperatureLogManager {
     this.utilService = utilService;
   }
 
-  upsert = async (
+  insert = async (
     temperatureLog: Partial<TemperatureLog>[]
   ): Promise<Partial<TemperatureLog>[]> => {
-    return this.databaseService.upsert(ENTITIES.TEMPERATURE_LOG, temperatureLog);
+    return this.databaseService.insert(ENTITIES.TEMPERATURE_LOG, temperatureLog);
   };
 
   addNewTemperatureLog = async (
@@ -29,7 +29,7 @@ export class TemperatureLogManager {
   addNewTemperatureLogs = async (
     temperatureLogs: Partial<TemperatureLog>[]
   ): Promise<Partial<TemperatureLog>[]> => {
-    return this.upsert(
+    return this.insert(
       temperatureLogs.map(temperatureLog => ({ id: this.utilService.uuid(), ...temperatureLog }))
     );
   };

--- a/src/features/Entities/TemperatureLog/TemperatureLogManager.ts
+++ b/src/features/Entities/TemperatureLog/TemperatureLogManager.ts
@@ -14,10 +14,10 @@ export class TemperatureLogManager {
     this.utilService = utilService;
   }
 
-  insert = async (
+  upsert = async (
     temperatureLog: Partial<TemperatureLog>[]
   ): Promise<Partial<TemperatureLog>[]> => {
-    return this.databaseService.insert(ENTITIES.TEMPERATURE_LOG, temperatureLog);
+    return this.databaseService.upsert(ENTITIES.TEMPERATURE_LOG, temperatureLog);
   };
 
   addNewTemperatureLog = async (
@@ -29,7 +29,7 @@ export class TemperatureLogManager {
   addNewTemperatureLogs = async (
     temperatureLogs: Partial<TemperatureLog>[]
   ): Promise<Partial<TemperatureLog>[]> => {
-    return this.insert(
+    return this.upsert(
       temperatureLogs.map(temperatureLog => ({ id: this.utilService.uuid(), ...temperatureLog }))
     );
   };


### PR DESCRIPTION
Previously after every log download, we reset the data collection interval.
This caused any logs at that time to be deleted.

Now we aren't removing any logs, and also not setting the data collection interval.

The code calculates how many log entries should be saved from the downloaded logs based on how many intervals are expected between the last log entry and now. It then assumes the timestamp for first log, it one interval since the last timestamp in the database.
Unless!
We have a less records than would be expected to fill the gap between the last record and now, then we assume the latest record is relative to now.
Or if we have more records than expect, we simply skip the extra records. (This is the main logic change in the PR)


Tested with a sensor on 1 minute interval, make sure that as we're heating the sensor up the temperatures trend up, while cooling it the temperatures go down...