### PR TITLE
Test sensor url

### DIFF
--- a/src/features/Sync/SyncSlice.ts
+++ b/src/features/Sync/SyncSlice.ts
@@ -57,11 +57,11 @@ const reducers = {
   tryIntegrating: () => {},
   tryTestConnection: {
     prepare: (
-      loginUrl: string,
+      serverUrl: string,
       username: string,
       password: string
     ): PrepareActionReturn<AuthenticateActionPayload> => ({
-      payload: { username, password, loginUrl },
+      payload: { username, password, serverUrl },
     }),
     reducer: () => {},
   },
@@ -89,8 +89,8 @@ const reducers = {
     },
   },
   authenticate: {
-    prepare: (loginUrl: string, username: string, password: string) => ({
-      payload: { loginUrl, username, password },
+    prepare: (serverUrl: string, username: string, password: string) => ({
+      payload: { serverUrl, username, password },
     }),
     reducer: () => {},
   },
@@ -176,11 +176,12 @@ const SyncSelector = {
 };
 
 function* authenticate({
-  payload: { loginUrl, username, password },
+  payload: { serverUrl, username, password },
 }: PayloadAction<AuthenticateActionPayload>): SagaIterator {
   const syncOutManager: SyncOutManager = yield call(getDependency, 'syncOutManager');
 
   try {
+    const loginUrl = `${serverUrl}/${ENDPOINT.LOGIN}`;
     yield call(syncOutManager.login, loginUrl, username, password);
     yield put(SyncAction.authenticateSuccess());
   } catch (e) {
@@ -320,12 +321,28 @@ function* enablePassiveSync(): SagaIterator {
 }
 
 function* tryTestConnection({
-  payload: { loginUrl, username, password },
+  payload: { serverUrl, username, password },
 }: PayloadAction<AuthenticateActionPayload>): SagaIterator {
   const syncOutManager: SyncOutManager = yield call(getDependency, 'syncOutManager');
   ToastAndroid.show('Testing Connection', ToastAndroid.SHORT);
   try {
-    yield call(syncOutManager.login, loginUrl, username, password);
+    const loginUrl = `${serverUrl}/${ENDPOINT.LOGIN}`;
+    const loginResponse = yield call(syncOutManager.login, loginUrl, username, password);
+    const { success } = loginResponse?.data ?? {};
+
+    if (success !== true) {
+      yield put(SyncAction.testConnectionFailure('Invalid response returned from login'));
+      return;
+    }
+
+    // login returned correctly, now test for a valid response from the sensor endpoint
+    const sensorUrl = `${serverUrl}/${ENDPOINT.SENSOR}`;
+    const sensorResponse = yield call(syncOutManager.syncSensors, sensorUrl, []);
+    const sensors = sensorResponse?.data;
+    if (!Array.isArray(sensors) || sensors.length !== 0) {
+      yield put(SyncAction.testConnectionFailure('Does not appear to be a cold chain server'));
+      return;
+    }
     yield put(SyncAction.testConnectionSuccess());
   } catch (e) {
     yield put(SyncAction.testConnectionFailure((e as Error).message));

--- a/src/features/Sync/types.ts
+++ b/src/features/Sync/types.ts
@@ -57,7 +57,7 @@ export interface UpdateSyncErrorActionPayload {
 }
 
 export interface AuthenticateActionPayload {
-  loginUrl: string;
+  serverUrl: string;
   username: string;
   password: string;
 }

--- a/src/ui/screens/settings/SyncSettingsScreen.tsx
+++ b/src/ui/screens/settings/SyncSettingsScreen.tsx
@@ -12,7 +12,6 @@ import {
 import { SettingAction, SettingSelector, SyncAction, SyncSelector } from '~features';
 import { t } from '~common/translations';
 import { useFormatter } from '~hooks';
-import { ENDPOINT } from '~features/Sync/SyncSlice';
 import { QRCodeScanner } from './QRCodeScanner';
 import { IconButton } from '~components/buttons';
 import { ToastAndroid } from 'react-native';
@@ -120,13 +119,7 @@ export const SyncSettingsScreen: FC = () => {
           label={t('TEST_CONNECTION')}
           subtext={t('TEST_CONNECTION_SUBTEXT')}
           onPress={() =>
-            dispatch(
-              SyncAction.tryTestConnection(
-                `${serverUrl}/${ENDPOINT.LOGIN}`,
-                authUsername,
-                authPassword
-              )
-            )
+            dispatch(SyncAction.tryTestConnection(serverUrl, authUsername, authPassword))
           }
         />
         <SettingsGroup title="Info">


### PR DESCRIPTION
Added a check into the server URL test which checks:
* that the server returns `{ success: true }` when you try to login
* that the server returns an empty array if you PUT an empty array of sensors

the second check might not be strictly necessary - but is a useful test to see if this is a cold chain API that we are looking at

To test? I tried using a dashboard URL and that returned 404, so did not repro the issue.
However, using the [PostTestServer](https://posttestserver.dev/p/3vwma67tmg21zd4t) works - as this returns a 200 response regardless of what you post to it. 