### PR TITLE
Keyboard appearance pushes input off screen

### DIFF
--- a/src/ui/layouts/SettingsEditModalLayout.tsx
+++ b/src/ui/layouts/SettingsEditModalLayout.tsx
@@ -1,5 +1,5 @@
-import React, { FC, ReactNode, useCallback, useEffect, useState } from 'react';
-import { useWindowDimensions, View, Pressable, Keyboard, ViewStyle } from 'react-native';
+import React, { FC, ReactNode } from 'react';
+import { useWindowDimensions, View, Pressable, ViewStyle } from 'react-native';
 import { STYLE, COLOUR } from '../../common/constants';
 import { Divider } from '../presentation';
 import { Column } from './Column';
@@ -31,32 +31,10 @@ export const SettingsEditModalLayout: FC<SettingsEditModalLayoutProps> = ({
   onClose,
 }) => {
   const { width } = useWindowDimensions();
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
-
-  const onKeyboardDidShow = useCallback(e => {
-    setKeyboardHeight(e.endCoordinates.height);
-  }, []);
-
-  const onKeyboardDidHide = useCallback(() => {
-    setKeyboardHeight(0);
-  }, []);
-
-  useEffect(() => {
-    Keyboard.addListener('keyboardDidShow', onKeyboardDidShow);
-    Keyboard.addListener('keyboardDidHide', onKeyboardDidShow);
-    return () => {
-      Keyboard.removeListener('keyboardDidShow', onKeyboardDidShow);
-      Keyboard.removeListener('keyboardDidHide', onKeyboardDidHide);
-    };
-  }, [onKeyboardDidHide, onKeyboardDidShow]);
 
   const internalContentContainerStyle = { ...style.container, width: width * 0.95 };
   return (
-    <FullScreenModal
-      isOpen={isOpen}
-      onClose={onClose}
-      style={{ paddingBottom: keyboardHeight + 50 }}
-    >
+    <FullScreenModal isOpen={isOpen} onClose={onClose} style={{ paddingBottom: 50 }}>
       <Pressable onPress={null}>
         <Column style={internalContentContainerStyle}>
           <View style={{ paddingVertical: 20 }}>{Title}</View>


### PR DESCRIPTION
Fixes #286 

Have removed the keyboard height being added to the padding on `FullScreenModal` as this isn't required for me, and causes the issue of the inputs being pushed out of sight.

To test: simply try to adjust the username or password in sync settings.

There is a [release apk](https://drive.google.com/file/d/1wC9wluSlpvjqgEiCHXYgcuJEc19LUDTd/view?usp=drive_link) available for testing
